### PR TITLE
feat(go.mod, main.go): coreos/pkg 패키지를 추가하고 환경 변수 지원 구현

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module flat
 
 go 1.23.0
 
-require k8s.io/klog/v2 v2.130.1
+require (
+	github.com/coreos/pkg v0.0.0-20240122114842-bbd7aa9bf6fb
+	k8s.io/klog/v2 v2.130.1
+)
 
 require github.com/go-logr/logr v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/coreos/pkg v0.0.0-20240122114842-bbd7aa9bf6fb h1:GIzvVQ9UkUlOhSDlqmrQAAAUd6R3E+caIisNEyWXvNE=
+github.com/coreos/pkg v0.0.0-20240122114842-bbd7aa9bf6fb/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/coreos/pkg/flagutil"
 	log "k8s.io/klog/v2"
 )
 
@@ -108,6 +109,11 @@ func init() {
 
 func copyFlag(name string) {
 	flatFlags.Var(flag.Lookup(name).Value, flag.Lookup(name).Name, flag.Lookup(name).Usage)
+
+	err := flagutil.SetFlagsFromEnv(flatFlags, "FLATD")
+	if err != nil {
+		log.Error("환경 변수에서 플래그를 설정할 수 없습니다.", err)
+	}
 }
 
 func usage() {


### PR DESCRIPTION
go.mod에 coreos/pkg 의존성을 추가하여 플래그 유틸리티를 사용하고,
main.go에서 환경 변수 FLATD로부터 플래그를 설정할 수 있도록 함.

close #7 
