### PR TITLE
fix(main.go): subnetLeaseRenewMargin 값의 유효성 검사 추가

### DIFF
--- a/main.go
+++ b/main.go
@@ -129,4 +129,9 @@ func main() {
 	}
 
 	log.Infof("CLI 플래그 설정 : %+v", opts)
+
+	if opts.subnetLeaseRenewMargin >= 60*24 || opts.subnetLeaseRenewMargin <= 0 {
+		log.Error("subnet-lease-renew-margin가 범위 밖의 값으로 설정되었습니다.")
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
유효하지 않은 값이 설정될 경우 에러 로그를 기록하고 종료하도록 함
close #9 
